### PR TITLE
Remove console log for no differences found

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ async function main() {
   console.log(`Current branch: ${currentBranch}`);
   console.log(`Target branch: ${targetBranch}`);
   const diff = execSync(`git diff ${targetBranch}..${currentBranch}`).toString();
+
+  console.log(diff,"diff")
   if (!diff.trim()) {
     // console.log('No differences found between branches.');
     return;
@@ -38,7 +40,7 @@ async function main() {
   }
   await git.push('origin', currentBranch);
   try {
-    console.log('Creating PR via GitHub API...');
+    // console.log('Creating PR via GitHub API...');
     const pr = await createPRWithToken(
       prMessage.title,
       prMessage.body,

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ async function main() {
   console.log(`Target branch: ${targetBranch}`);
   const diff = execSync(`git diff ${targetBranch}..${currentBranch}`).toString();
   if (!diff.trim()) {
-    console.log('No differences found between branches.');
+    // console.log('No differences found between branches.');
     return;
   }
   const prMessage = await generatePRContent(diff, currentBranch, targetBranch);


### PR DESCRIPTION
This PR removes the console log that indicates no differences were found between the branches. This was likely done to reduce noise in the console output when the script is run and no changes are present.